### PR TITLE
Add workaround for Docker build failures and some improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM archlinux/base:latest
 
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
+    curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
+    bsdtar -C / -xvf "$patched_glibc"
+
 RUN pacman -Syu --noconfirm
 RUN pacman -Syu --noconfirm texlive-langjapanese
 RUN pacman -Syu --noconfirm pandoc pandoc-crossref otf-ipafont

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # web-report-compiler
+The web server which compiles a MarkDown file into a PDF.
+
+## usage
+1. Run `docker-compose up --build`
+2. Open `http://localhost:5000/{token}` in your browser.
+
+By default, the token is `hogehoge`. (So open `http://localhost:5000/hogehoge`.)

--- a/app/serv.py
+++ b/app/serv.py
@@ -43,9 +43,11 @@ def index():
         filename = "report.pdf"
 
         if not error:
-            return send_file(filename, as_attachment = True, \
+            response = send_file(filename, as_attachment=True,
                 attachment_filename = filename, \
                 mimetype = PDF_MIMETYPE)
+            response.headers['Content-Disposition'] = 'inline; filename=%s' % filename
+            return response
     
     return render_template('index.html', code=code, error=error)
 


### PR DESCRIPTION
This PR changes three things mainly.

First, this fixes a Docker build failure which happens when using ArchLinux image.
See: https://www.reddit.com/r/archlinux/comments/lek2ba/arch_linux_on_docker_ci_could_not_find_or_read/
I could fix this issue by referencing https://github.com/qutebrowser/qutebrowser/commit/478e4de7bd1f26bebdcdc166d5369b2b5142c3e2.

Second, this changes behavior when browsers receive a resulting PDF file (`report.pdf`).
In my environment, the browser tries to download the PDF. But I want it to open within the browser, so I added some workarounds to make Flask do so.

Finally, this updates the README.
I added a simple explanation of this project and the usage.