### PR TITLE
Improve portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ The app compiles a MarkDown file into a PDF.
 - nix
 
 ## usage
+
+First, ensure the ipafont package is installed on your system.
+
+```/etc/nixos/configuration.nix
+  fonts = {
+    fonts = [
+      pkgs.ipafont
+      # ...
+```
+
+Then, launch application:
+
 ```sh
 git clone https://github.com/akakou-hobby/report-compiler/
 cd report-compiler/

--- a/main.sh
+++ b/main.sh
@@ -1,1 +1,1 @@
-nix-shell shell.nix --pure --keep XDG_DATA_DIRS --run "python3 app.py"
+nix-shell shell.nix --pure --keep XDG_DATA_DIRS --keep XAUTHORITY --run "python3 app.py"

--- a/shell.nix
+++ b/shell.nix
@@ -18,13 +18,15 @@ mkShell {
     gtk3
     gtkmm3
     webkitgtk
-    python311
-    python311Packages.pywebview
-    python311Packages.pyqtwebengine
-    python311Packages.pyqt5
-    python311Packages.pygobject3
-    python311Packages.gst-python
+    python310
+    python310Packages.pywebview
+    python310Packages.pyqtwebengine
+    python310Packages.pyqt5
+    python310Packages.pygobject3
+    python310Packages.gst-python
     gobject-introspection
      gsettings-desktop-schemas
+     shadow
+     xorg.xhost
   ];
 }


### PR DESCRIPTION
There were some bugs that had reduced portability (i.e., it didn't work on my machine).

This PR makes some modifications and additions to improve portability to make this app easy to use.

- Downgrade Python runtime to 3.10
- Add .gitkeep to templates/workspace
- Add a command line option to main.sh to keep an X environment variable
- Add an extra confirmation step on setup